### PR TITLE
Prepare and deploy fin-o1 model to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# Vietnam
-Test
+# Project
+
+See `fin-o1-demo` for a cross-platform demo of `TheFinAI/Fin-o1-8B` with CLI, Gradio, and Streamlit runners.

--- a/fin-o1-demo/.gitignore
+++ b/fin-o1-demo/.gitignore
@@ -1,0 +1,21 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Environments
+.venv/
+.env
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Models and logs
+models/
+checkpoints/
+outputs/
+logs/
+
+# Streamlit
+.streamlit/

--- a/fin-o1-demo/README.md
+++ b/fin-o1-demo/README.md
@@ -1,0 +1,44 @@
+# Fin-o1-8B Cross-Platform Demo
+
+This folder provides ready-to-run scripts to download, setup, and demo `TheFinAI/Fin-o1-8B` on Windows and Linux/macOS.
+
+## Quickstart (Linux/macOS)
+
+```bash
+cd fin-o1-demo
+bash setup.sh            # create venv and install deps (CPU torch by default)
+# Optional: pre-download model (can be large)
+# bash setup.sh --download
+
+# CLI demo
+bash run_cli.sh "List 3 short key takeaways from AAPL's latest earnings."
+
+# Gradio UI (http://127.0.0.1:7860)
+bash run_gradio.sh
+
+# Streamlit UI (http://127.0.0.1:8501)
+bash run_streamlit.sh
+```
+
+## Quickstart (Windows)
+
+```bat
+cd fin-o1-demo
+setup.bat               
+REM Optional: pre-download model
+REM setup.bat --download
+
+REM CLI demo
+run_cli.bat "List 3 short key takeaways from AAPL's latest earnings."
+
+REM Gradio UI (http://127.0.0.1:7860)
+run_gradio.bat
+
+REM Streamlit UI (http://127.0.0.1:8501)
+run_streamlit.bat
+```
+
+## Notes
+- Default install uses CPU PyTorch for maximum compatibility. If you have CUDA, install a matching Torch build from `pytorch.org` and the scripts will auto-detect GPU.
+- Set `HF_TOKEN` if the model requires authentication.
+- Large model downloads: enable fast download via `HF_HUB_ENABLE_HF_TRANSFER=1` (already enabled in scripts).

--- a/fin-o1-demo/download_model.py
+++ b/fin-o1-demo/download_model.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+import argparse
+import os
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+
+
+def main():
+	parser = argparse.ArgumentParser(description="Pre-download a Hugging Face model snapshot")
+	parser.add_argument("--model-id", default="TheFinAI/Fin-o1-8B")
+	parser.add_argument("--token", default=os.environ.get("HF_TOKEN", ""), help="Optional HF token (or set HF_TOKEN env)")
+	parser.add_argument("--local-dir", default=str(Path("models") / "TheFinAI__Fin-o1-8B"))
+	args = parser.parse_args()
+
+	os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+	local_dir = Path(args.local_dir)
+	local_dir.mkdir(parents=True, exist_ok=True)
+
+	print(f"Downloading {args.model_id} to {local_dir} ...")
+	path = snapshot_download(
+		args.model_id,
+		local_dir=str(local_dir),
+		local_dir_use_symlinks=False,
+		use_auth_token=(args.token if args.token else None),
+	)
+	print(f"Done. Files in: {path}")
+
+
+if __name__ == "__main__":
+	main()

--- a/fin-o1-demo/fin_o1_demo.py
+++ b/fin-o1-demo/fin_o1_demo.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+import argparse
+import os
+import sys
+from typing import Optional
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+
+def create_generator(model_id: str, device_preference: Optional[str] = None):
+	os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+	trust_remote_code = True
+
+	if device_preference is None:
+		if torch.cuda.is_available():
+			device_preference = "cuda"
+		elif torch.backends.mps.is_available():
+			device_preference = "mps"
+		else:
+			device_preference = "cpu"
+
+	if device_preference == "cuda":
+		dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+		device_map = "auto"
+	elif device_preference == "mps":
+		dtype = torch.float16
+		device_map = {"": "mps"}
+	else:
+		dtype = torch.float32
+		device_map = {"": "cpu"}
+
+	tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=True, trust_remote_code=trust_remote_code)
+	model = AutoModelForCausalLM.from_pretrained(
+		model_id,
+		trust_remote_code=trust_remote_code,
+		torch_dtype=dtype,
+		device_map=device_map,
+	)
+
+	gen = pipeline(
+		"text-generation",
+		model=model,
+		tokenizer=tokenizer,
+		return_full_text=False,
+		batch_size=1,
+	)
+	return gen
+
+
+def main():
+	parser = argparse.ArgumentParser(description="Run a quick Fin-o1-8B generation demo")
+	parser.add_argument("--model-id", default="TheFinAI/Fin-o1-8B", help="Hugging Face model id")
+	parser.add_argument("--prompt", default="List 3 short key takeaways from AAPL's latest earnings.", help="Prompt to generate from")
+	parser.add_argument("--max-new-tokens", type=int, default=128)
+	parser.add_argument("--temperature", type=float, default=0.7)
+	parser.add_argument("--top-p", type=float, default=0.9)
+	parser.add_argument("--device", choices=["auto", "cpu", "cuda", "mps"], default="auto")
+	args = parser.parse_args()
+
+	device_pref = None if args.device == "auto" else args.device
+
+	print(f"Loading model: {args.model_id}", file=sys.stderr)
+	generator = create_generator(args.model_id, device_preference=device_pref)
+
+	print("\nPrompt:\n" + args.prompt)
+	outputs = generator(
+		args.prompt,
+		max_new_tokens=args.max_new_tokens,
+		do_sample=True,
+		temperature=args.temperature,
+		top_p=args.top_p,
+		repetition_penalty=1.05,
+	)
+	text = outputs[0]["generated_text"] if outputs and isinstance(outputs, list) else str(outputs)
+	print("\nModel output:\n" + text)
+
+
+if __name__ == "__main__":
+	main()

--- a/fin-o1-demo/gradio_app.py
+++ b/fin-o1-demo/gradio_app.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+import os
+from typing import Optional
+
+import torch
+import gradio as gr
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+
+def create_generator(model_id: str, device_preference: Optional[str] = None):
+	os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+	trust_remote_code = True
+
+	if device_preference is None:
+		if torch.cuda.is_available():
+			device_preference = "cuda"
+		elif torch.backends.mps.is_available():
+			device_preference = "mps"
+		else:
+			device_preference = "cpu"
+
+	if device_preference == "cuda":
+		dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+		device_map = "auto"
+	elif device_preference == "mps":
+		dtype = torch.float16
+		device_map = {"": "mps"}
+	else:
+		dtype = torch.float32
+		device_map = {"": "cpu"}
+
+	tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=True, trust_remote_code=trust_remote_code)
+	model = AutoModelForCausalLM.from_pretrained(
+		model_id,
+		trust_remote_code=trust_remote_code,
+		torch_dtype=dtype,
+		device_map=device_map,
+	)
+
+	gen = pipeline(
+		"text-generation",
+		model=model,
+		tokenizer=tokenizer,
+		return_full_text=False,
+		batch_size=1,
+	)
+	return gen
+
+
+generator_cache = {"pipeline": None, "model_id": None, "device": None}
+
+
+def generate(prompt, max_new_tokens, temperature, top_p, model_id, device):
+	if generator_cache["pipeline"] is None or generator_cache["model_id"] != model_id or generator_cache["device"] != device:
+		generator_cache["pipeline"] = create_generator(model_id, None if device == "auto" else device)
+		generator_cache["model_id"] = model_id
+		generator_cache["device"] = device
+
+	outputs = generator_cache["pipeline"](
+		prompt,
+		max_new_tokens=int(max_new_tokens),
+		do_sample=True,
+		temperature=float(temperature),
+		top_p=float(top_p),
+		repetition_penalty=1.05,
+	)
+	return outputs[0]["generated_text"]
+
+
+def app():
+	with gr.Blocks(title="Fin-o1-8B Demo") as demo:
+		gr.Markdown("# Fin-o1-8B Demo\nEnter a prompt and generate text.")
+		with gr.Row():
+			prompt = gr.Textbox(label="Prompt", value="List 3 short key takeaways from AAPL's latest earnings.", lines=4)
+		with gr.Row():
+			max_new_tokens = gr.Slider(16, 1024, value=256, step=8, label="max_new_tokens")
+			temperature = gr.Slider(0.0, 2.0, value=0.7, step=0.05, label="temperature")
+			top_p = gr.Slider(0.1, 1.0, value=0.9, step=0.05, label="top_p")
+		with gr.Row():
+			model_id = gr.Textbox(label="Model ID", value="TheFinAI/Fin-o1-8B")
+			device = gr.Dropdown(["auto", "cpu", "cuda", "mps"], value="auto", label="Device")
+		btn = gr.Button("Generate")
+		output = gr.Textbox(label="Output", lines=12)
+
+		btn.click(generate, inputs=[prompt, max_new_tokens, temperature, top_p, model_id, device], outputs=output)
+	return demo
+
+
+if __name__ == "__main__":
+	app().launch()

--- a/fin-o1-demo/requirements.txt
+++ b/fin-o1-demo/requirements.txt
@@ -1,0 +1,10 @@
+accelerate>=0.30.0
+transformers>=4.41.2
+huggingface_hub>=0.23.4
+hf-transfer>=0.1.6
+safetensors>=0.4.3
+einops>=0.7.0
+tqdm>=4.66.4
+gradio>=4.44.0
+streamlit>=1.37.0
+python-dotenv>=1.0.1

--- a/fin-o1-demo/run_cli.bat
+++ b/fin-o1-demo/run_cli.bat
@@ -1,0 +1,10 @@
+@echo off
+setlocal ENABLEDELAYEDEXPANSION
+cd /d %~dp0
+
+set PROMPT=%*
+if "%PROMPT%"=="" set PROMPT=List 3 short key takeaways from AAPL's latest earnings.
+
+set HF_HUB_ENABLE_HF_TRANSFER=1
+.venv\Scripts\python fin_o1_demo.py --prompt "%PROMPT%" --max-new-tokens 128
+endlocal

--- a/fin-o1-demo/run_cli.sh
+++ b/fin-o1-demo/run_cli.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$PROJECT_DIR"
+
+# Create venv if missing
+if [ ! -d .venv ]; then
+	python3 -m venv .venv
+fi
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+python -m pip install -U pip
+# Install CPU Torch by default for portability
+python -m pip install --index-url https://download.pytorch.org/whl/cpu torch
+python -m pip install -r requirements.txt
+
+export HF_HUB_ENABLE_HF_TRANSFER=1
+
+PROMPT=${1:-"List 3 short key takeaways from AAPL's latest earnings."}
+
+python fin_o1_demo.py --prompt "$PROMPT" --max-new-tokens 128

--- a/fin-o1-demo/run_gradio.bat
+++ b/fin-o1-demo/run_gradio.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+cd /d %~dp0
+
+set HF_HUB_ENABLE_HF_TRANSFER=1
+.venv\Scripts\python gradio_app.py
+endlocal

--- a/fin-o1-demo/run_gradio.sh
+++ b/fin-o1-demo/run_gradio.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$PROJECT_DIR"
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+export HF_HUB_ENABLE_HF_TRANSFER=1
+
+python gradio_app.py

--- a/fin-o1-demo/run_streamlit.bat
+++ b/fin-o1-demo/run_streamlit.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+cd /d %~dp0
+
+set HF_HUB_ENABLE_HF_TRANSFER=1
+.venv\Scripts\python -m streamlit run streamlit_app.py --server.headless true
+endlocal

--- a/fin-o1-demo/run_streamlit.sh
+++ b/fin-o1-demo/run_streamlit.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$PROJECT_DIR"
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+export HF_HUB_ENABLE_HF_TRANSFER=1
+
+streamlit run streamlit_app.py --server.headless true

--- a/fin-o1-demo/setup.bat
+++ b/fin-o1-demo/setup.bat
@@ -1,0 +1,28 @@
+@echo off
+setlocal ENABLEDELAYEDEXPANSION
+cd /d %~dp0
+
+where py >nul 2>nul
+if %errorlevel%==0 (
+	set PYTHON=py -3
+) else (
+	set PYTHON=python
+)
+
+%PYTHON% -m venv .venv
+
+set PIP=.venv\Scripts\python -m pip
+%PIP% install -U pip
+REM Install default torch (CPU-only by default if no CUDA)
+%PIP% install torch --index-url https://download.pytorch.org/whl/cpu
+%PIP% install -r requirements.txt
+
+if "%1"=="--download" (
+	set HF_HUB_ENABLE_HF_TRANSFER=1
+	.venv\Scripts\python download_model.py --model-id TheFinAI/Fin-o1-8B
+)
+
+echo.
+echo Setup complete. Activate with:
+echo .venv\Scripts\activate
+endlocal

--- a/fin-o1-demo/setup.sh
+++ b/fin-o1-demo/setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$PROJECT_DIR"
+
+python3 -m venv .venv
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+python -m pip install -U pip
+# Install CPU Torch by default for maximum compatibility
+python -m pip install --index-url https://download.pytorch.org/whl/cpu torch
+python -m pip install -r requirements.txt
+
+# Optional: pre-download the model
+if [ "${1:-}" = "--download" ]; then
+	export HF_HUB_ENABLE_HF_TRANSFER=1
+	python download_model.py --model-id TheFinAI/Fin-o1-8B
+fi
+
+echo "\nSetup complete. Activate with:"
+echo "source .venv/bin/activate"

--- a/fin-o1-demo/streamlit_app.py
+++ b/fin-o1-demo/streamlit_app.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+import os
+from typing import Optional
+
+import torch
+import streamlit as st
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+
+def create_generator(model_id: str, device_preference: Optional[str] = None):
+	os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+	trust_remote_code = True
+
+	if device_preference is None:
+		if torch.cuda.is_available():
+			device_preference = "cuda"
+		elif torch.backends.mps.is_available():
+			device_preference = "mps"
+		else:
+			device_preference = "cpu"
+
+	if device_preference == "cuda":
+		dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+		device_map = "auto"
+	elif device_preference == "mps":
+		dtype = torch.float16
+		device_map = {"": "mps"}
+	else:
+		dtype = torch.float32
+		device_map = {"": "cpu"}
+
+	tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=True, trust_remote_code=trust_remote_code)
+	model = AutoModelForCausalLM.from_pretrained(
+		model_id,
+		trust_remote_code=trust_remote_code,
+		torch_dtype=dtype,
+		device_map=device_map,
+	)
+
+	gen = pipeline(
+		"text-generation",
+		model=model,
+		tokenizer=tokenizer,
+		return_full_text=False,
+		batch_size=1,
+	)
+	return gen
+
+
+@st.cache_resource(show_spinner=False)
+def get_generator(model_id: str, device: str):
+	device_pref = None if device == "auto" else device
+	return create_generator(model_id, device_pref)
+
+
+def main():
+	st.set_page_config(page_title="Fin-o1-8B Demo", layout="wide")
+	st.title("Fin-o1-8B Demo")
+
+	with st.sidebar:
+		st.header("Settings")
+		model_id = st.text_input("Model ID", value="TheFinAI/Fin-o1-8B")
+		device = st.selectbox("Device", options=["auto", "cpu", "cuda", "mps"], index=0)
+		max_new_tokens = st.slider("max_new_tokens", 16, 1024, 256, 8)
+		temperature = st.slider("temperature", 0.0, 2.0, 0.7, 0.05)
+		top_p = st.slider("top_p", 0.1, 1.0, 0.9, 0.05)
+
+	prompt = st.text_area("Prompt", value="List 3 short key takeaways from AAPL's latest earnings.", height=160)
+
+	if st.button("Generate", use_container_width=True):
+		with st.spinner("Loading model and generating..."):
+			generator = get_generator(model_id, device)
+			outputs = generator(
+				prompt,
+				max_new_tokens=int(max_new_tokens),
+				do_sample=True,
+				temperature=float(temperature),
+				top_p=float(top_p),
+				repetition_penalty=1.05,
+			)
+			text = outputs[0]["generated_text"]
+		st.subheader("Output")
+		st.write(text)
+
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
Adds a cross-platform demo for the Fin-o1-8B model with CLI, Gradio, and Streamlit interfaces to enable immediate use by others.

---
<a href="https://cursor.com/background-agent?bcId=bc-21475dab-135d-4ec0-afdb-1b7b1213958d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21475dab-135d-4ec0-afdb-1b7b1213958d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

